### PR TITLE
Add "dependent: :destroy" to avoid Foreign key constraint error with delete

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -1,5 +1,5 @@
 class Candidate < ApplicationRecord
 
   validates :name, presence: true
-  has_many :vote_logs
+  has_many :vote_logs, dependent: :destroy
 end


### PR DESCRIPTION
Add "dependent: :destroy" to maintain referential integrity when deleting the candidate who has vote_logs.